### PR TITLE
Bugfix: pagination page prop and ellipsis click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telegram-apps/telegram-ui",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telegram-apps/telegram-ui",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telegram-apps/telegram-ui",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "World-class, ultimate UI developer toolkit.",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",

--- a/src/components/Navigation/Pagination/Pagination.module.css
+++ b/src/components/Navigation/Pagination/Pagination.module.css
@@ -36,6 +36,7 @@
 }
 
 .button--ellipsis {
+  cursor: default;
   opacity: 1;
 }
 

--- a/src/components/Navigation/Pagination/Pagination.tsx
+++ b/src/components/Navigation/Pagination/Pagination.tsx
@@ -88,7 +88,7 @@ export const Pagination = ({
             })}
             aria-disabled={item.disabled || undefined}
             aria-current={item['aria-current']}
-            onClick={item.disabled ? undefined : item.onClick}
+            onClick={item.disabled || isEllipsis ? undefined : item.onClick}
           >
             {getPaginationChild(item)}
           </Headline>

--- a/src/components/Navigation/Pagination/hooks/usePagination.ts
+++ b/src/components/Navigation/Pagination/hooks/usePagination.ts
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-
 import { range } from 'helpers/array';
+import { useCustomEnsuredControl } from 'hooks/useEnsureControl';
 
 import { PaginationType } from './enum';
 import { UsePaginationItem, UsePaginationProps } from './types';
@@ -21,7 +20,10 @@ export const usePagination = ({
   page: pageProp,
   siblingCount = 1,
 }: UsePaginationProps): UsePaginationItem[] => {
-  const [page, setPageState] = useState(pageProp === undefined ? defaultPage : pageProp);
+  const [page, setPageState] = useCustomEnsuredControl({
+    value: pageProp,
+    defaultValue: defaultPage,
+  });
 
   const handleClick: UsePaginationProps['onChange'] = (event, value) => {
     if (!pageProp) {


### PR DESCRIPTION
Problem: 
1. pagination doesn't update on page prop change
2. when I click on ellipsis, pagination breaks because page number becomes 0 

Also I processed this file with prettier.

Basically the changes are:
1. add useeffect that tracks pageProp changes
2. check if value !== 0 before setting page
<img width="562" alt="image" src="https://github.com/Telegram-Mini-Apps/TelegramUI/assets/52068583/3aea6c4f-34f0-4c3e-a728-2d3016f717d3">
