### PR TITLE
[Service]: Relative secondary color

### DIFF
--- a/src/components/Service/AppRoot/AppRoot.module.css
+++ b/src/components/Service/AppRoot/AppRoot.module.css
@@ -60,7 +60,7 @@
   --tgui--segmented_control_active_bg: #FFFFFF;
   --tgui--card_bg_color: #FFFFFF;
   --tgui--secondary_hint_color: #A2ACB0;
-  --tgui--secondary_fill: color-mix(in srgb, var(--tgui--accent_text_color) 10%, transparent);
+  --tgui--secondary_fill: rgba(67, 120, 255, .10);
   --tgui--green: #31D158;
   --tgui--destructive_background: #E53935;
   --tgui--primary_code_highlight: #4378FF;
@@ -127,7 +127,7 @@
   --tgui--segmented_control_active_bg: #2F2F2F;
   --tgui--card_bg_color: #242424;
   --tgui--secondary_hint_color: #78797E;
-  --tgui--secondary_fill: color-mix(in srgb, var(--tgui--accent_text_color) 15%, transparent);
+  --tgui--secondary_fill: rgba(41, 144, 255, .15);
   --tgui--green: #32E55E;
   --tgui--destructive_background: rgba(255, 35, 35, .02);
   --tgui--primary_code_highlight: #2990FF;
@@ -153,5 +153,15 @@
 @supports (padding-top: env(safe-area-inset-bottom)) {
   .wrapper {
     --tgui--safe_area_inset_bottom: env(safe-area-inset-bottom);
+  }
+}
+
+@supports (color: color-mix(in srgb, var(--tgui--accent_text_color) 10%, transparent)) {
+  .wrapper {
+    --tgui--secondary_fill: color-mix(in srgb, var(--tgui--accent_text_color) 10%, transparent);
+  }
+
+  .wrapper--dark {
+    --tgui--secondary_fill: color-mix(in srgb, var(--tgui--accent_text_color) 15%, transparent);
   }
 }

--- a/src/components/Service/AppRoot/AppRoot.module.css
+++ b/src/components/Service/AppRoot/AppRoot.module.css
@@ -60,7 +60,7 @@
   --tgui--segmented_control_active_bg: #FFFFFF;
   --tgui--card_bg_color: #FFFFFF;
   --tgui--secondary_hint_color: #A2ACB0;
-  --tgui--secondary_fill: rgba(67, 120, 255, .10);
+  --tgui--secondary_fill: color-mix(in srgb, var(--tgui--accent_text_color) 10%, transparent);
   --tgui--green: #31D158;
   --tgui--destructive_background: #E53935;
   --tgui--primary_code_highlight: #4378FF;
@@ -127,7 +127,7 @@
   --tgui--segmented_control_active_bg: #2F2F2F;
   --tgui--card_bg_color: #242424;
   --tgui--secondary_hint_color: #78797E;
-  --tgui--secondary_fill: rgba(41, 144, 255, .15);
+  --tgui--secondary_fill: color-mix(in srgb, var(--tgui--accent_text_color) 15%, transparent);
   --tgui--green: #32E55E;
   --tgui--destructive_background: rgba(255, 35, 35, .02);
   --tgui--primary_code_highlight: #2990FF;


### PR DESCRIPTION
Currently, `--tgui--secondary_fill` has a hardcoded blue-ish opaque value. This works with default theme being blue, but results in poor visual consistency when using custom themes.

For example, Telegram Web K in dark mode uses purple as accent color and `base` platform. When using `Tabbar` accent color is passed properly, however the secondary fill, which serves as background for `Tabbar.Item`, remains blue-ish, breaking overall color scheme.

![image](https://github.com/user-attachments/assets/fc11e33b-b786-4073-9606-8c41e87a26f5)

This PR suggests using `color-mix` CSS function to determine `--tgui--secondary_fill` based on current theme's accent color. This feature is [supported in all major browsers](https://caniuse.com/?search=color-mix) and therefore is usable for Telegram Mini Apps.