### PR TITLE
[Banner]: JSDoc fix and Figma match

### DIFF
--- a/src/components/Blocks/Banner/Banner.stories.tsx
+++ b/src/components/Blocks/Banner/Banner.stories.tsx
@@ -25,8 +25,9 @@ export const Playground: Story = {
   args: {
     type: 'section',
     before: <UIImage size={48} />,
+    callout: 'Urgent notification',
     header: 'Introducing TON Space',
-    subheader: 'Start exploring TON in a new, better way',
+    description: 'Start exploring TON in a new, better way',
     children: (
       <>
         <Button size="s">Try it out</Button>

--- a/src/components/Blocks/Banner/Banner.tsx
+++ b/src/components/Blocks/Banner/Banner.tsx
@@ -12,9 +12,9 @@ import { Icon28Close } from 'icons/28/close';
 import { Icon28CloseAmbient } from 'icons/28/close_ambient';
 
 import { Tappable } from 'components/Service/Tappable/Tappable';
-import { Caption } from 'components/Typography';
 import { Subheadline } from 'components/Typography/Subheadline/Subheadline';
 import { Text } from 'components/Typography/Text/Text';
+import { BannerDescriptionTypography } from './components/BannerDescriptionTypography/BannerDescriptionTypography';
 
 export interface BannerProps extends HTMLAttributes<HTMLDivElement> {
   /** Specifies the banner's layout style, which can affect its positioning and styling. */
@@ -57,15 +57,6 @@ export const Banner = ({
 }: BannerProps) => {
   const platform = usePlatform();
   const hasBackground = hasReactNode(background);
-  let descriptionNode;
-
-  if (hasReactNode(description)) {
-    if (platform === 'ios') {
-      descriptionNode = <Caption className={styles.description} level="1">{description}</Caption>;
-    } else {
-      descriptionNode = <Subheadline className={styles.description} level="2">{description}</Subheadline>;
-    }
-  }
 
   return (
     <section
@@ -89,7 +80,7 @@ export const Banner = ({
         {hasReactNode(callout) && <Subheadline className={styles.subheader} level="2">{callout}</Subheadline>} 
         {hasReactNode(header) && <Text className={styles.title} weight="2">{header}</Text>}
         {hasReactNode(subheader) && <Subheadline className={styles.subheader} level="2">{subheader}</Subheadline>}
-        {descriptionNode}
+        {hasReactNode(description) && <BannerDescriptionTypography className={styles.description}>{description}</BannerDescriptionTypography>}
       </div>
       {onCloseIcon && (
         <Tappable onClick={onCloseIcon} className={styles.close} Component="div">

--- a/src/components/Blocks/Banner/Banner.tsx
+++ b/src/components/Blocks/Banner/Banner.tsx
@@ -57,6 +57,15 @@ export const Banner = ({
 }: BannerProps) => {
   const platform = usePlatform();
   const hasBackground = hasReactNode(background);
+  let descriptionNode;
+
+  if (hasReactNode(description)) {
+    if (platform === 'ios') {
+      descriptionNode = <Caption className={styles.description} level="1">{description}</Caption>;
+    } else {
+      descriptionNode = <Subheadline className={styles.description} level="2">{description}</Subheadline>;
+    }
+  }
 
   return (
     <section
@@ -80,12 +89,7 @@ export const Banner = ({
         {hasReactNode(callout) && <Subheadline className={styles.subheader} level="2">{callout}</Subheadline>} 
         {hasReactNode(header) && <Text className={styles.title} weight="2">{header}</Text>}
         {hasReactNode(subheader) && <Subheadline className={styles.subheader} level="2">{subheader}</Subheadline>}
-        {hasReactNode(description) && <Caption className={styles.description} level="1">{description}</Caption>}
-        {hasReactNode(children) && (
-          <div className={styles.buttons}>
-            {children}
-          </div>
-        )}
+        {descriptionNode}
       </div>
       {onCloseIcon && (
         <Tappable onClick={onCloseIcon} className={styles.close} Component="div">

--- a/src/components/Blocks/Banner/Banner.tsx
+++ b/src/components/Blocks/Banner/Banner.tsx
@@ -12,6 +12,7 @@ import { Icon28Close } from 'icons/28/close';
 import { Icon28CloseAmbient } from 'icons/28/close_ambient';
 
 import { Tappable } from 'components/Service/Tappable/Tappable';
+import { Caption } from 'components/Typography';
 import { Subheadline } from 'components/Typography/Subheadline/Subheadline';
 import { Text } from 'components/Typography/Text/Text';
 
@@ -20,6 +21,8 @@ export interface BannerProps extends HTMLAttributes<HTMLDivElement> {
   type?: 'section' | 'inline';
   /** Element(s) to be placed on the left side of the banner, typically an icon or an image. */
   before?: ReactNode;
+  /** Content displayed above the main content as a subheading */
+  callout?: ReactNode;
   /** The main text or title displayed in the banner. */
   header?: ReactNode;
   /** Additional information or subtext displayed below the header. */
@@ -35,12 +38,14 @@ export interface BannerProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * The `Banner` component renders a small numeric or dot indicator, typically used for notifications, statuses, or counts.
- * It supports several visual modes for different contexts (e.g., critical, primary) and can be sized normally or enlarged.
+ * The `Banner` component renders a prominent graphical element, typically displayed at the top of a page or section, 
+ * designed to grab the user's attention and convey important information. 
+ * It is a versatile tool used for various purposes such as branding, promotion, announcements, or navigation.
  */
 export const Banner = ({
   type,
   before,
+  callout,
   header,
   subheader,
   description,
@@ -72,9 +77,10 @@ export const Banner = ({
       )}
       {before}
       <div className={styles.middle}>
+        {hasReactNode(callout) && <Subheadline className={styles.subheader} level="2">{callout}</Subheadline>} 
         {hasReactNode(header) && <Text className={styles.title} weight="2">{header}</Text>}
         {hasReactNode(subheader) && <Subheadline className={styles.subheader} level="2">{subheader}</Subheadline>}
-        {hasReactNode(description) && <Subheadline className={styles.description} level="2">{description}</Subheadline>}
+        {hasReactNode(description) && <Caption className={styles.description} level="1">{description}</Caption>}
         {hasReactNode(children) && (
           <div className={styles.buttons}>
             {children}

--- a/src/components/Blocks/Banner/components/BannerDescriptionTypography/BannerDescriptionTypography.tsx
+++ b/src/components/Blocks/Banner/components/BannerDescriptionTypography/BannerDescriptionTypography.tsx
@@ -10,9 +10,9 @@ export interface BannerDescriptionTypographyProps extends Omit<TypographyProps, 
 export const BannerDescriptionTypography = (props: BannerDescriptionTypographyProps) => {
   const platform = usePlatform();
 
-  if (platform === 'base') {
-    return <Subheadline level="2" {...props} />;
+  if (platform === 'ios') {
+    return <Caption level="1" {...props} />;
   }
 
-  return <Caption level="1" {...props} />;
+  return <Subheadline level="2" {...props} />;
 };

--- a/src/components/Blocks/Banner/components/BannerDescriptionTypography/BannerDescriptionTypography.tsx
+++ b/src/components/Blocks/Banner/components/BannerDescriptionTypography/BannerDescriptionTypography.tsx
@@ -1,0 +1,18 @@
+import { usePlatform } from 'hooks/usePlatform';
+
+import { Caption } from 'components/Typography/Caption/Caption';
+import { Subheadline } from 'components/Typography/Subheadline/Subheadline';
+import { TypographyProps } from 'components/Typography/Typography';
+
+export interface BannerDescriptionTypographyProps extends Omit<TypographyProps, 'level'> {
+}
+
+export const BannerDescriptionTypography = (props: BannerDescriptionTypographyProps) => {
+  const platform = usePlatform();
+
+  if (platform === 'base') {
+    return <Subheadline level="2" {...props} />;
+  }
+
+  return <Caption level="1" {...props} />;
+};


### PR DESCRIPTION
1. Fixed `Banner` JSDoc, which would previously be copied from `Badge` component.
2. Added `callout` prop which wasn't present in current implementation though described in this library's Figma file. 
3. `description` content changed to slightly different typography, also matching Figma's version.