### PR TITLE
banner hotfix & release 2.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telegram-apps/telegram-ui",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "World-class, ultimate UI developer toolkit.",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",

--- a/src/components/Blocks/Banner/Banner.tsx
+++ b/src/components/Blocks/Banner/Banner.tsx
@@ -81,6 +81,11 @@ export const Banner = ({
         {hasReactNode(header) && <Text className={styles.title} weight="2">{header}</Text>}
         {hasReactNode(subheader) && <Subheadline className={styles.subheader} level="2">{subheader}</Subheadline>}
         {hasReactNode(description) && <BannerDescriptionTypography className={styles.description}>{description}</BannerDescriptionTypography>}
+        {hasReactNode(children) && (
+          <div className={styles.buttons}>
+            {children}
+          </div>
+        )}
       </div>
       {onCloseIcon && (
         <Tappable onClick={onCloseIcon} className={styles.close} Component="div">


### PR DESCRIPTION
It appears my latest contribution broke `Banner` by accidentally removing rendering of `children`. This PR should fix this and up version to `2.1.7`.