### PR TITLE
feat: update section background color

### DIFF
--- a/src/components/Blocks/Section/Section.module.css
+++ b/src/components/Blocks/Section/Section.module.css
@@ -1,11 +1,11 @@
 .wrapper--base .bodyWithHeader {
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.10);
-  background: var(--tgui--bg_color);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+  background: var(--tgui--section_bg_color);
 }
 
 .wrapper--ios .body {
   border-radius: 12px;
-  background: var(--tgui--bg_color);
+  background: var(--tgui--section_bg_color);
 }
 
 .wrapper--ios .body > :first-child {


### PR DESCRIPTION
Currently, at least on iOS in dark mode, the section background does not feel native. That is because Telegram added another color to be passed to Mini Apps: `--tg-theme-section-bg-color`. This one is obtained by AppRoot, but not used in the actual Section component for some reason. With current Storybook configuration you will not see any difference between the two variants, however in actual production apps that utilize user's personal color themes this will create effect. For example, my theme is `#000000` background, `#1c1c1d` secondary background and `#2c2c2e` section background. This means that currently I will have a dark-gray-ish page background (when using secondary color, which is arguably the case for most mini apps) with black cells. That is not native at all, as proven by native app's Settings Tab which has black background (primary) and gray cells (section background).

This is a UI-breaking change, but a proper one I believe.