### PR TITLE
Allows Chip to render Radio components

### DIFF
--- a/src/components/Form/Chip/Chip.stories.tsx
+++ b/src/components/Form/Chip/Chip.stories.tsx
@@ -4,6 +4,7 @@ import { hideControls, setControlsTypes } from 'storybook/controls';
 
 import { Avatar } from 'components/Blocks/Avatar/Avatar';
 import { List } from 'components/Blocks/List/List';
+import { Radio } from 'components/Form/Radio/Radio';
 import { Chip } from './Chip';
 
 const meta = {
@@ -21,28 +22,32 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const chips = [
-  'Chip',
-  '\'n\'',
-  'Dale',
-];
+const chips = ['Chip', '\'n\'', 'Dale'];
 
 export const Playground: Story = {
   render: (args) => (
-    <List style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}>
+    <List
+      style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}
+    >
       <div style={{ display: 'flex', gap: 16 }}>
         {chips.map((text) => (
-          <Chip key={text} {...args}>{text}</Chip>
+          <Chip key={text} {...args}>
+            {text}
+          </Chip>
         ))}
       </div>
       <div style={{ display: 'flex', gap: 16 }}>
         {chips.map((text) => (
-          <Chip mode="mono" key={text} {...args}>{text}</Chip>
+          <Chip mode="mono" key={text} {...args}>
+            {text}
+          </Chip>
         ))}
       </div>
       <div style={{ display: 'flex', gap: 16 }}>
         {chips.map((text) => (
-          <Chip mode="outline" key={text} {...args}>{text}</Chip>
+          <Chip mode="outline" key={text} {...args}>
+            {text}
+          </Chip>
         ))}
       </div>
     </List>
@@ -51,7 +56,9 @@ export const Playground: Story = {
 
 export const WithAfter: Story = {
   render: () => (
-    <List style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}>
+    <List
+      style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}
+    >
       <div style={{ display: 'flex', gap: 8 }}>
         <Chip mode="elevated" after={<Icon16Cancel />}>
           Elevated
@@ -69,7 +76,9 @@ export const WithAfter: Story = {
 
 export const WithBefore: Story = {
   render: () => (
-    <List style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}>
+    <List
+      style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}
+    >
       <div style={{ display: 'flex', gap: 8 }}>
         <Chip mode="elevated" before={<Avatar size={20} />}>
           Elevated
@@ -85,3 +94,22 @@ export const WithBefore: Story = {
   ),
 };
 
+export const WithRadioBefore: Story = {
+  render: () => (
+    <List
+      style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}
+    >
+      <div style={{ display: 'flex', gap: 8 }}>
+        <Chip mode="elevated" before={<Radio name="test" defaultChecked />}>
+          Elevated
+        </Chip>
+        <Chip mode="mono" before={<Radio name="test" />}>
+          Mono
+        </Chip>
+        <Chip mode="outline" before={<Radio name="test" />}>
+          Outline
+        </Chip>
+      </div>
+    </List>
+  ),
+};

--- a/src/components/Form/Chip/Chip.stories.tsx
+++ b/src/components/Form/Chip/Chip.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   argTypes: {
     ...hideControls('before', 'after'),
     ...setControlsTypes(['children'], 'text'),
+    ...hideControls('Component'),
   },
 } satisfies Meta<typeof Chip>;
 

--- a/src/components/Form/Chip/Chip.stories.tsx
+++ b/src/components/Form/Chip/Chip.stories.tsx
@@ -100,13 +100,17 @@ export const WithRadioBefore: Story = {
       style={{ background: 'var(--tgui--secondary_bg_color)', padding: 20 }}
     >
       <div style={{ display: 'flex', gap: 8 }}>
-        <Chip mode="elevated" before={<Radio name="test" defaultChecked />}>
+        <Chip
+          mode="elevated"
+          Component="label"
+          before={<Radio name="test" defaultChecked />}
+        >
           Elevated
         </Chip>
-        <Chip mode="mono" before={<Radio name="test" />}>
+        <Chip mode="mono" Component="label" before={<Radio name="test" />}>
           Mono
         </Chip>
-        <Chip mode="outline" before={<Radio name="test" />}>
+        <Chip mode="outline" Component="label" before={<Radio name="test" />}>
           Outline
         </Chip>
       </div>

--- a/src/components/Form/Chip/Chip.tsx
+++ b/src/components/Form/Chip/Chip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AllHTMLAttributes, ReactNode } from 'react';
+import { AllHTMLAttributes, ElementType, ReactNode } from 'react';
 import styles from './Chip.module.css';
 
 import { classNames } from 'helpers/classNames';
@@ -19,6 +19,8 @@ export interface ChipProps extends AllHTMLAttributes<HTMLDivElement> {
   after?: ReactNode;
   /** The main text content of the chip. */
   children?: ReactNode;
+  /** Specifies the HTML tag or React component used to render the Chip, defaulting to `div`. */
+  Component?: ElementType;
 }
 
 const modeStyles = {
@@ -37,26 +39,19 @@ export const Chip = ({
   after,
   className,
   children,
+  Component,
   ...restProps
 }: ChipProps) => {
   const platform = usePlatform();
 
   return (
     <Tappable
-      Component="div"
+      Component={Component || 'div'}
       interactiveAnimation="opacity"
-      className={classNames(
-        styles.wrapper,
-        modeStyles[mode],
-        className,
-      )}
+      className={classNames(styles.wrapper, modeStyles[mode], className)}
       {...restProps}
     >
-      {hasReactNode(before) && (
-        <div className={styles.before}>
-          {before}
-        </div>
-      )}
+      {hasReactNode(before) && <div className={styles.before}>{before}</div>}
       <Subheadline
         className={styles.text}
         level={platform === 'ios' ? '2' : '1'}
@@ -64,11 +59,7 @@ export const Chip = ({
       >
         {children}
       </Subheadline>
-      {hasReactNode(after) && (
-        <div className={styles.after}>
-          {after}
-        </div>
-      )}
+      {hasReactNode(after) && <div className={styles.after}>{after}</div>}
     </Tappable>
   );
 };

--- a/src/components/Form/Chip/Chip.tsx
+++ b/src/components/Form/Chip/Chip.tsx
@@ -39,14 +39,14 @@ export const Chip = ({
   after,
   className,
   children,
-  Component,
+  Component = 'div',
   ...restProps
 }: ChipProps) => {
   const platform = usePlatform();
 
   return (
     <Tappable
-      Component={Component || 'div'}
+      Component={Component}
       interactiveAnimation="opacity"
       className={classNames(styles.wrapper, modeStyles[mode], className)}
       {...restProps}

--- a/src/components/Form/Radio/Radio.module.css
+++ b/src/components/Form/Radio/Radio.module.css
@@ -1,6 +1,7 @@
 .wrapper {
   position: relative;
   cursor: pointer;
+  display: block;
 }
 
 .wrapper--disabled {


### PR DESCRIPTION
Adds a `display: block` to the radio label so it "takes space". This was causing a bug in safari (and thus iOS Telegram) where using Radios inside Chips was causing the "checked" svg to render outside the component.

Screenshot of the issue before this fix is applied (on Safari):

![CleanShot 2024-08-14 at 09 49 25@2x](https://github.com/user-attachments/assets/b79b9d42-f8d6-401c-b8fb-5a585b8be94b)

Edit: It also allows Component to be specified on Chip, so that a label can be rendered for Radios which makes the whole component select its own option.
