### PR TITLE
[Checkbox, Textarea]: forwardRef

### DIFF
--- a/src/components/Form/Checkbox/Checkbox.tsx
+++ b/src/components/Form/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import styles from './Checkbox.module.css';
 
 import { classNames } from 'helpers/classNames';
@@ -18,13 +18,13 @@ export interface CheckboxProps
  * Renders a checkbox input with custom styling and optional indeterminate state.
  * The component visually hides the actual input element for accessibility while providing a custom styled appearance.
  */
-export const Checkbox = ({
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({
   style,
   className,
   disabled,
   indeterminate,
   ...restProps
-}: CheckboxProps) => (
+}, ref) => (
   <label
     className={classNames(
       styles.wrapper,
@@ -34,6 +34,7 @@ export const Checkbox = ({
   >
     <VisuallyHidden
       {...restProps}
+      ref={ref}
       Component="input"
       type="checkbox"
       className={styles.input}
@@ -44,4 +45,4 @@ export const Checkbox = ({
       {indeterminate ? <IconCheckboxIndeterminate /> : <IconCheckboxChecked />}
     </div>
   </label>
-);
+));

--- a/src/components/Form/Textarea/Textarea.tsx
+++ b/src/components/Form/Textarea/Textarea.tsx
@@ -17,7 +17,7 @@ export interface TextareaProps extends Omit<FormPublicProps, 'after' | 'before'>
  * This component inherits the flexible design of the `FormInput`, allowing it to display a header and reflect different status styles.
  * The appearance and behavior of the textarea can be customized through various props, providing a seamless integration with forms.
  */
-export const Textarea = forwardRef<HTMLInputElement, TextareaProps>(({
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
   type = 'text',
   header,
   status,

--- a/src/components/Form/Textarea/Textarea.tsx
+++ b/src/components/Form/Textarea/Textarea.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import styles from './Textarea.module.css';
 
 import { classNames } from 'helpers/classNames';
@@ -17,13 +17,13 @@ export interface TextareaProps extends Omit<FormPublicProps, 'after' | 'before'>
  * This component inherits the flexible design of the `FormInput`, allowing it to display a header and reflect different status styles.
  * The appearance and behavior of the textarea can be customized through various props, providing a seamless integration with forms.
  */
-export const Textarea = ({
+export const Textarea = forwardRef<HTMLInputElement, TextareaProps>(({
   type = 'text',
   header,
   status,
   className,
   ...restProps
-}: TextareaProps) => {
+}, ref) => {
   const platform = usePlatform();
 
   const TypographyComponent = platform === 'ios' ? Text : Subheadline;
@@ -38,6 +38,7 @@ export const Textarea = ({
       )}
     >
       <TypographyComponent
+        ref={ref}
         Component="textarea"
         className={styles.textarea}
         type={type}
@@ -45,4 +46,4 @@ export const Textarea = ({
       />
     </FormInput>
   );
-};
+});


### PR DESCRIPTION
Forward <Textarea> and <Checkbox> ref to child input element.

It's mandatory for use with Preact