### PR TITLE
Remove unsupported placeholder property

### DIFF
--- a/src/components/Form/Select/Select.stories.tsx
+++ b/src/components/Form/Select/Select.stories.tsx
@@ -19,10 +19,7 @@ export const Playground: StoryObj<SelectProps> = {
       width: 240,
       background: 'var(--tgui--secondary_bg_color)',
     }}>
-      <Select
-        header="Select"
-        placeholder="I am usual input, just leave me alone"
-      >
+      <Select header="Select">
         <option>Hello</option>
         <option>Okay</option>
       </Select>


### PR DESCRIPTION
Looks like the `placeholder` property does not supported:

<img width="701" alt="screenshot" src="https://github.com/user-attachments/assets/f10d3649-e54b-4622-aa11-4cc1cba92846">
